### PR TITLE
Fixed bug on section titles of Deep Dives

### DIFF
--- a/workshop/content/docs/api-deep-dive/common.md
+++ b/workshop/content/docs/api-deep-dive/common.md
@@ -4,7 +4,7 @@ title: OGC API - Common
 
 # OGC API - Common
 
-!!! abstract Audience
+!!! abstract "Audience"
     Students that are familiar with web services and APIs, and want to have
     an overview of OGC API - Common draft standard
 

--- a/workshop/content/docs/api-deep-dive/environmental-data-retrieval.md
+++ b/workshop/content/docs/api-deep-dive/environmental-data-retrieval.md
@@ -4,7 +4,7 @@ title: OGC API - Environmental Data Retrieval
 
 # OGC API - Environmental Data Retrieval
 
-!!! abstract Audience
+!!! abstract "Audience"
     Students that are familiar with web services and APIs, and want to have
     an overview of OGC API - Environmental Data Retrieval standard
 

--- a/workshop/content/docs/api-deep-dive/features.md
+++ b/workshop/content/docs/api-deep-dive/features.md
@@ -4,7 +4,7 @@ title: OGC API - Features
 
 # OGC API - Features
 
-!!! abstract Audience
+!!! abstract "Audience"
     Students that are familiar with web services and APIs, and want to have
     an overview of OGC API - Features standard
 

--- a/workshop/content/docs/api-deep-dive/maps.md
+++ b/workshop/content/docs/api-deep-dive/maps.md
@@ -4,7 +4,7 @@ title: OGC API - Maps
 
 # OGC API - Maps
 
-!!! abstract Audience
+!!! abstract "Audience"
     Students that are familiar with web services and APIs, and want to have
     an overview of OGC API - Maps standard
 

--- a/workshop/content/docs/api-deep-dive/processes.md
+++ b/workshop/content/docs/api-deep-dive/processes.md
@@ -4,7 +4,7 @@ title: OGC API - Processes
 
 # OGC API - Processes
 
-!!! abstract Audience
+!!! abstract "Audience"
     Students that are familiar with web services and APIs, and want to have
     an overview of OGC API - Processes standard
 

--- a/workshop/content/docs/api-deep-dive/records.md
+++ b/workshop/content/docs/api-deep-dive/records.md
@@ -4,7 +4,7 @@ title: OGC API - Records
 
 # OGC API - Records
 
-!!! abstract Audience
+!!! abstract "Audience"
     Students that are familiar with web services and APIs, and want to have
     an overview of OGC API - Records standard
 

--- a/workshop/content/docs/api-deep-dive/sensorthings.md
+++ b/workshop/content/docs/api-deep-dive/sensorthings.md
@@ -4,7 +4,7 @@ title: OGC SensorThings API
 
 # OGC SensorThings API
 
-!!! abstract Audience
+!!! abstract "Audience"
     Students that are familiar with web services and want to have an
     overview of the SensorThings Application Programming Interface (API) standard
 

--- a/workshop/content/docs/api-deep-dive/tiles.md
+++ b/workshop/content/docs/api-deep-dive/tiles.md
@@ -4,7 +4,7 @@ title: OGC API - Tiles
 
 # OGC API - Tiles
 
-!!! abstract Audience
+!!! abstract "Audience"
     Students that are familiar with web services and APIs, and want to have
     an overview of OGC API - Tiles standard
 


### PR DESCRIPTION
- Added missing quotes on "Audience section", which were causing the tag to be interpreted as title.

This PR addresses this issue: https://github.com/opengeospatial/ogcapi-workshop/issues/56