### PR TITLE
Fixed url of compliant products page

### DIFF
--- a/workshop/content/docs/compliance-and-certification.md
+++ b/workshop/content/docs/compliance-and-certification.md
@@ -10,7 +10,7 @@ The [OGC Compliance Program](https://www.ogc.org/compliance) provides the resour
 
 The primary purpose of the program is to increase systems interoperability while reducing technology risks by providing a process whereby compliance with OGC standards can be tested.
 
-You can browse the [OGC compliance product page](https://www.ogc.org/resources/certified-products/) to check the list of products certified by OGC.
+You can browse the [OGC compliance product page](https://portal.ogc.org/public_ogc/compliance/compliant.php?display_opt=1&org_match=Crunchy+Data) to check the list of products certified by OGC.
 
 ## TEAM Engine
 


### PR DESCRIPTION
The current url for compliant products seems to be broken:

```
curl -I https://www.ogc.org/certified-products/   
HTTP/1.1 404 Not Found
Server: nginx/1.22.1
Date: Wed, 11 Mar 2026 18:56:46 GMT
Content-Type: text/html; charset=UTF-8
Connection: keep-alive
Expires: Wed, 11 Jan 1984 05:00:00 GMT
Cache-Control: no-cache, must-revalidate, max-age=0, no-store, private
X-Nitro-Cache: MISS
X-Nitro-Disabled-Reason: 404
X-Nitro-Disabled: 1
Link: <https://www.ogc.org/wp-json/>; rel="https://api.w.org/"
Strict-Transport-Security: max-age=31536000
Content-Security-Policy: upgrade-insecure-requests
```